### PR TITLE
feat: Enhance duplicate content reporting and console output

### DIFF
--- a/app/reporter.py
+++ b/app/reporter.py
@@ -26,14 +26,16 @@ def setup_logging():
         pass
 
 def log_error(url, msg):
-    """Registra un mensaje de error en el archivo de logs."""
+    """Registra un mensaje de error en el archivo de logs y en la consola."""
     store.error_count += 1
+    print(f"\n[ERROR] en {url}:\n  {msg}\n")
     with open(error_log_file, "a") as f:
         f.write(f"[{url}] - {msg}\n\n")
 
 def log_warning(url, msg):
-    """Registra un mensaje de advertencia en el archivo de logs."""
+    """Registra un mensaje de advertencia en el archivo de logs y en la consola."""
     store.warning_count += 1
+    print(f"\n[AVISO] en {url}:\n  {msg}\n")
     with open(warning_log_file, "a") as f:
         f.write(f"[{url}] - {msg}\n\n")
 
@@ -45,7 +47,7 @@ def update_progress(url):
 
 def print_summary():
     """Muestra el resumen final del rastreo."""
-    print("\\n" + "="*50)
+    print("\n" + "="*50)
     print("Crawl finalizado:")
 
     validated_pct = 0

--- a/app/validator.py
+++ b/app/validator.py
@@ -44,13 +44,17 @@ async def validate(session, semaphore, meta, url):
         warnings.append(f"Description fuera de rango ({len(meta['description'])} caracteres)")
 
     # Detección de duplicados
-    store.register_title(url, meta['title'])
-    if meta['title'] and len(store.title_index.get(meta['title'], [])) > 1:
-        errors.append(f"Title duplicado: {meta['title']}")
+    if meta['title']:
+        if meta['title'] in store.title_index:
+            original_url = store.title_index[meta['title']][0]
+            errors.append(f"Title duplicado: '{meta['title']}' (original: {original_url})")
+        store.register_title(url, meta['title'])
 
-    store.register_description(url, meta['description'])
-    if meta['description'] and len(store.description_index.get(meta['description'], [])) > 1:
-        errors.append(f"Description duplicada: {meta['description']}")
+    if meta['description']:
+        if meta['description'] in store.description_index:
+            original_url = store.description_index[meta['description']][0]
+            errors.append(f"Description duplicada: '{meta['description']}' (original: {original_url})")
+        store.register_description(url, meta['description'])
 
     # Verificación de enlaces e imágenes
     tasks = []


### PR DESCRIPTION
- The duplicate title and description error messages now include both the duplicate and original URLs, providing better context for debugging.
- The console output formatting has been improved by adding line breaks to the `log_error` and `log_warning` functions, ensuring that each log message is clearly separated.
- The `print_summary` function has been adjusted to include newlines for better readability.