### PR TITLE
feat: Normalize URLs by removing trailing slashes

### DIFF
--- a/app/crawler.py
+++ b/app/crawler.py
@@ -50,9 +50,12 @@ async def crawl(start_url):
     queue = asyncio.Queue()
     semaphore = asyncio.Semaphore(config.CONCURRENCY)
 
+    # Normalizar la URL de inicio para evitar duplicados por la barra final
+    normalized_url = start_url.rstrip('/')
+
     store.total_links = 1
-    store.seen_urls.add(start_url)
-    await queue.put(start_url)
+    store.seen_urls.add(normalized_url)
+    await queue.put(normalized_url)
 
     async with aiohttp.ClientSession() as session:
         tasks = []

--- a/app/parser.py
+++ b/app/parser.py
@@ -24,7 +24,7 @@ def parse(html, base_url):
     for link in soup.find_all('a', href=True):
         href = link['href']
         if not href.startswith(('http://', 'https://')):
-            abs_url = urljoin(base_url, href)
+            abs_url = urljoin(base_url, href).rstrip('/')
             if config.BASE_DOMAIN in abs_url:
                 links.append(abs_url)
 

--- a/app/store.py
+++ b/app/store.py
@@ -18,13 +18,15 @@ warning_count = 0
 
 def add_page(url, meta):
     """Agrega una página y sus metadatos al store."""
+    normalized_url = url.rstrip('/')
     global pages
-    pages[url] = meta
-    seen_urls.add(url)
+    pages[normalized_url] = meta
+    seen_urls.add(normalized_url)
 
 def is_visited(url):
     """Verifica si una URL ya ha sido visitada."""
-    return url in seen_urls
+    normalized_url = url.rstrip('/')
+    return normalized_url in seen_urls
 
 def register_title(url, title):
     """Registra un title para detectar duplicados."""


### PR DESCRIPTION
Removes trailing slashes from URLs to ensure that URLs with and without a final slash are treated as the same entity. This prevents duplicate content issues and ensures that the crawler does not process the same page multiple times.

- The `start_url` is normalized in `app/crawler.py`.
- New links are normalized in `app/parser.py`.
- URLs are normalized before being added to the store in `app/store.py`.